### PR TITLE
options should go before the input files

### DIFF
--- a/lib/FFmpeg/Command.pm
+++ b/lib/FFmpeg/Command.pm
@@ -117,8 +117,8 @@ sub execute {
     my $cmd = [
         $self->ffmpeg,
         '-y',
-        map ( { ( '-i', $_ ) } @$files ),
         @{ $self->options },
+        map ( { ( '-i', $_ ) } @$files ),
     ];
 
     # add output file only if we have one


### PR DESCRIPTION
this avoids processing/decoding the file when performing a seek for
instance.
