### PR TITLE
-iオプションの位置を変更

### DIFF
--- a/lib/FFmpeg/Command.pm
+++ b/lib/FFmpeg/Command.pm
@@ -119,8 +119,8 @@ sub execute {
     my $cmd = [
         $self->ffmpeg,
         '-y',
-        @{ $self->options },
         map ( { ( '-i', $_ ) } @$files ),
+        @{ $self->options },
     ];
 
     # add output file only if we have one


### PR DESCRIPTION
こんにちは。

-iオプションをその他のオプションより前に持って来る修正です。ffmpegのバージョンによっては問題になるようです。

http://isaji.cheap.jp/popfulmail/index.php?%B0%CB%BB%B0%BC%A1%2F2008-03-24

手元のFreeBSDでは問題なかったんですが、Ubuntuで同じ問題がでました。
