### PR TITLE
Support for avconv

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -15,4 +15,5 @@ my $ff = FFmpeg::Command->new();
 $ff->options( [ '-version' ] );
 $ff->exec();
 my $out = $ff->stderr || $ff->stdout;
-like $out, qr/^FFmpeg version/i;
+my $expected = $ff->ffmpeg . ' version';
+like $out, qr/^$expected/i;

--- a/t/01-coderef.t
+++ b/t/01-coderef.t
@@ -22,4 +22,5 @@ $ff->exec();
 
 my $out = $stderr || $stdout;
 
-like $out, qr/^FFmpeg version/i;
+my $expected = $ff->ffmpeg . ' version';
+like $out, qr/^$expected/i;

--- a/t/02-option_a.t
+++ b/t/02-option_a.t
@@ -17,5 +17,5 @@ my $cmd = $ffmpeg->_compose_command;
 
 is(
     join(' ', @$cmd),
-    'ffmpeg -y -ga -gb -ia -ib -i filename1 -oa -ob output_file'
+    $ffmpeg->ffmpeg . ' -y -ga -gb -ia -ib -i filename1 -oa -ob output_file'
 );

--- a/t/03-option_b.t
+++ b/t/03-option_b.t
@@ -15,5 +15,5 @@ my $cmd = $ffmpeg->_compose_command;
 
 is(
     join(' ', @$cmd),
-    'ffmpeg -y -i filename1 -ga -gb -ia -ib -oa -ob output_file'
+    $ffmpeg->ffmpeg . ' -y -i filename1 -ga -gb -ia -ib -oa -ob output_file'
 );

--- a/t/04-option_c.t
+++ b/t/04-option_c.t
@@ -17,5 +17,5 @@ my $cmd = $ffmpeg->_compose_command;
 
 is(
     join(' ', @$cmd),
-    'ffmpeg -y -ga -gb -ia -ib -i filename1 -ia -ib -i filename2 -oa -ob output_file'
+    $ffmpeg->ffmpeg . ' -y -ga -gb -ia -ib -i filename1 -ia -ib -i filename2 -oa -ob output_file'
 );

--- a/t/05-option_d.t
+++ b/t/05-option_d.t
@@ -13,5 +13,5 @@ my $cmd = $ffmpeg->_compose_command;
 
 is(
     join(' ', @$cmd),
-    'ffmpeg -y -ga -gb -ia1 -ib1 -i filename1 -ia2 -ib2 -i filename2 -oa -ob output_file',
+    $ffmpeg->ffmpeg . ' -y -ga -gb -ia1 -ib1 -i filename1 -ia2 -ib2 -i filename2 -oa -ob output_file',
 );

--- a/t/06-output_options.t
+++ b/t/06-output_options.t
@@ -24,7 +24,7 @@ my $cmd = $ffmpeg->_compose_command;
 
 is(
     join(' ', @$cmd),
-    'ffmpeg -y -i in.mp4 -acodec libaac -b 600 -f mp4 -vcodec mpeg4 -ar 48000 -s 320x240 -ab 64 out.mp4'
+    $ffmpeg->ffmpeg . ' -y -i in.mp4 -acodec libaac -b 600 -f mp4 -vcodec mpeg4 -ar 48000 -s 320x240 -ab 64 out.mp4'
 );
 
 $ffmpeg = FFmpeg::Command->new;
@@ -37,5 +37,5 @@ $ffmpeg->output_options({
 $cmd = $ffmpeg->_compose_command;
 is(
     join(' ', @$cmd),
-    'ffmpeg -y -i in.mp4 -b 600 -acodec libfaac -f mp4 -vcodec mpeg4 -ar 48000 -s 320x240 -ab 64 out.mp4'
+    $ffmpeg->ffmpeg . ' -y -i in.mp4 -b 600 -acodec libfaac -f mp4 -vcodec mpeg4 -ar 48000 -s 320x240 -ab 64 out.mp4'
 );


### PR DESCRIPTION
FFmpeg::Command is great, but it does not support the newer avconv utitiliy which seems to be replacing ffmpeg.

This commit lets FFmpeg::Command fall back to using avconv if ffmpeg is not present.
